### PR TITLE
lib/Event.js でConst Enumを定義するように修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.3.3
+* lib/Event.js で実態を定義するように修正
+
 ## 1.3.2
 * strict化対応
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/playlog",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "The interface definition of Playlog, the serialization format of Akashic game execution",
   "main": "lib/index.js",
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "declaration": true,
     "removeComments": true,
+    "preserveConstEnums": true,
     "outDir": "./lib",
     "strict": true
   },


### PR DESCRIPTION
### 概要
* typescriptのトランスパイルで生成されるlib/Event.jsにConst Enumが定義されていなかったので、トランスパイス時に定義されるように修正

### やったこと
* tsconfig.jsonに `"preserveConstEnums": true` を追加