### PR TITLE
add min-release-age in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-prefix='~'
+min-release-age=7


### PR DESCRIPTION
This PR adds `min-release-age=7` to .npmrc as requested.