### PR TITLE
chore: add devEngines.packageManager to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,12 @@
     "textlint-rule-no-mix-dearu-desumasu": "^6.0.0",
     "textlint-rule-prh": "^6.0.0",
     "typescript": "^5.2.2"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.11.0",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
This PR adds `devEngines.packageManager` to package.json to enforce npm version.